### PR TITLE
Adding two convenience methods to Option.

### DIFF
--- a/src/collections/Collection.php
+++ b/src/collections/Collection.php
@@ -75,11 +75,11 @@ abstract class Collection implements Iterator, ArrayAccess
 	{
 		if ($this->containsKey($key))
 		{
-			return new Some($this->data[$key]);
+			return Option::of($this->data[$key]);
 		}
 		else
 		{
-			return new None();
+			return Option::empty();
 		}
 	}
 	
@@ -97,11 +97,11 @@ abstract class Collection implements Iterator, ArrayAccess
 	{
 		if ($this->containsValue($value))
 		{
-			return new Some(array_search($value, $this->data, true));
+			return Option::of(array_search($value, $this->data, true));
 		}
 		else
 		{
-			return new None();
+			return Option::empty();
 		}
 	}
 	
@@ -136,7 +136,7 @@ abstract class Collection implements Iterator, ArrayAccess
 	{
 		$data = $this->find($predicate, false, $findFirst ? 1 : -1);
 		
-		return empty($data) ? new None() : new Some($data[0]);
+		return empty($data) ? Option::empty() : Option::of($data[0]);
 	}
 	
 	/**
@@ -155,7 +155,7 @@ abstract class Collection implements Iterator, ArrayAccess
 	{
 		$data = $this->find($predicate, true, $findFirst ? 1 : -1);
 		
-		return empty($data) ? new None() : new Some($data[0]);
+		return empty($data) ? Option::empty() : Option::of($data[0]);
 	}
 	
 	/**

--- a/src/collections/Option.php
+++ b/src/collections/Option.php
@@ -3,6 +3,16 @@ namespace js\tools\commons\collections;
 
 abstract class Option
 {
+	public static function empty(): None
+	{
+		return new None();
+	}
+	
+	public static function of($value): Some
+	{
+		return new Some($value);
+	}
+	
 	public function isEmpty(): bool
 	{
 		return ($this instanceof None);

--- a/src/collections/Option.php
+++ b/src/collections/Option.php
@@ -13,6 +13,17 @@ abstract class Option
 		return new Some($value);
 	}
 	
+	/**
+	 * @param mixed $value
+	 * @return Option {@link None} if the value is null, {@link Some} otherwise.
+	 */
+	public static function ofNullable($value): Option
+	{
+		return (($value === null)
+			? new None()
+			: new Some($value));
+	}
+	
 	public function isEmpty(): bool
 	{
 		return ($this instanceof None);

--- a/src/traits/DataAccessor.php
+++ b/src/traits/DataAccessor.php
@@ -2,9 +2,7 @@
 namespace js\tools\commons\traits;
 
 use InvalidArgumentException;
-use js\tools\commons\collections\None;
 use js\tools\commons\collections\Option;
-use js\tools\commons\collections\Some;
 
 /**
  * This trait adds the ability to access array data in a convenient manner,
@@ -124,14 +122,14 @@ trait DataAccessor
 		// Necessary because down the line the string is split into parts.
 		if (is_string($key) && isset($data[$key]))
 		{
-			return new Some($data[$key]);
+			return Option::of($data[$key]);
 		}
 		
 		$parts = self::getKeyParts($key);
 		
 		if (empty($parts))
 		{
-			return new None();
+			return Option::empty();
 		}
 		
 		$value = $data;
@@ -144,11 +142,11 @@ trait DataAccessor
 			}
 			else
 			{
-				return new None();
+				return Option::empty();
 			}
 		}
 		
-		return new Some($value);
+		return Option::of($value);
 	}
 	
 	/**

--- a/tests/collections/OptionTest.php
+++ b/tests/collections/OptionTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace js\tools\commons\tests\collections;
+
+use js\tools\commons\collections\None;
+use js\tools\commons\collections\Option;
+use js\tools\commons\collections\Some;
+use PHPUnit\Framework\TestCase;
+
+class OptionTest extends TestCase
+{
+	public function testEmpty(): void
+	{
+		$empty = Option::empty();
+		
+		$this->assertInstanceOf(None::class, $empty);
+	}
+	
+	public function testOf(): void
+	{
+		$value = 'some value';
+		$notEmpty = Option::of($value);
+		
+		$this->assertInstanceOf(Some::class, $notEmpty);
+		$this->assertSame($value, $notEmpty->get());
+	}
+}

--- a/tests/collections/OptionTest.php
+++ b/tests/collections/OptionTest.php
@@ -23,4 +23,20 @@ class OptionTest extends TestCase
 		$this->assertInstanceOf(Some::class, $notEmpty);
 		$this->assertSame($value, $notEmpty->get());
 	}
+	
+	public function testOfNullableEmpty(): void
+	{
+		$empty = Option::ofNullable(null);
+		
+		$this->assertInstanceOf(None::class, $empty);
+	}
+	
+	public function testOfNullableNotEmpty(): void
+	{
+		$value = 'some value';
+		$notEmpty = Option::ofNullable($value);
+		
+		$this->assertInstanceOf(Some::class, $notEmpty);
+		$this->assertSame($value, $notEmpty->get());
+	}
 }


### PR DESCRIPTION
The idea is taken from Java, where `Optional` has such methods.
This allows to avoid unnecessary imports for `None` and `Some`.